### PR TITLE
repro dropshot issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,16 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "a"
-version = "0.1.2-alpha.0"
+version = "0.1.2"
+dependencies = [
+ "b",
+]
 
 [[package]]
 name = "b"
-version = "0.1.2-alpha.0"
-
-[[package]]
-name = "foo"
-version = "0.1.2-alpha.0"
-dependencies = [
- "a",
- "b",
-]
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,2 @@
 [workspace]
 members = ["a", "b"]
-
-[package]
-name = "foo"
-version = "0.1.2-alpha.0"
-authors = ["Ed Page <epage@duosecurity.com>"]
-edition = "2018"
-publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
-a = { path = "a", version = "^0.1.2-alpha.0"}
-b = { path = "b", version = "^0.1.2-alpha.0"}

--- a/a/Cargo.toml
+++ b/a/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "a"
-version = "0.1.2-alpha.0"
+version = "0.1.2"
 authors = ["Ed Page <epage@duosecurity.com>"]
 edition = "2018"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dependencies.b]
+version = "0.1.2"
+path = "../b"

--- a/b/Cargo.toml
+++ b/b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b"
-version = "0.1.2-alpha.0"
+version = "0.1.2"
 authors = ["Ed Page <epage@duosecurity.com>"]
 edition = "2018"
 publish = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
I think I misunderstood this issue before.

This PR updates this repo to mirror the initial state [where I reported a problem](https://github.com/sunng87/cargo-release/issues/206#issuecomment-771268715).  In summary: this PR removes the crate in the root, changes "a" to depend on "b", and both "a" and "b" are at v0.1.2.  (It's possible this wasn't necessary.)

When I ran into this problem, what I was _trying_ to do was clean up from a previous failed `cargo release`.  That previous failure was my fault: I configured the tag prefix to be "", so both "a" and "b" would have the same tags.  `cargo release` tried to create a second tag with the same name and bailed out.  Most of the release had completed at that point, so I thought I could clean up by re-releasing the same version, but skipping the publish and push steps.  So I did the equivalent of this command in this repo (after my PR):

```
$ cargo release --skip-push -vv 0.1.2
Release
  a 0.1.2
  b 0.1.2
? [y/N] 
y
[2021-02-02T18:16:26Z DEBUG] Creating git tag a-v0.1.2
[2021-02-02T18:16:26Z DEBUG] Creating git tag b-v0.1.2
[2021-02-02T18:16:26Z INFO ] Starting a's next development iteration 0.1.3-alpha.0
[master 0d12a9a] (cargo-release) start next development iteration 0.1.3-alpha.0
 2 files changed, 2 insertions(+), 2 deletions(-)
[2021-02-02T18:16:26Z INFO ] Starting b's next development iteration 0.1.3-alpha.0
[2021-02-02T18:16:26Z WARN ] Fatal: Invalid TOML file format: Error during execution of `cargo metadata`: error: no matching package named `b` found
    location searched: /Users/dap/oxide/cargo-release-test/b
    prerelease package needs to be specified explicitly
    b = { version = "0.1.3-alpha.0" }
    required by package `a v0.1.3-alpha.0 (/Users/dap/oxide/cargo-release-test/a)`
    
```

I'm not sure why this _doesn't_ work.  It'd be nice if it did.  If not, it'd be nice if it didn't leave the repository in this broken state:

```
$ git show
commit 0d12a9a40b0e4081c378a780cd61caa2c6babf3d (HEAD -> master)
Author: David Pacheco <dap@oxidecomputer.com>
Date:   Tue Feb 2 10:16:26 2021 -0800

    (cargo-release) start next development iteration 0.1.3-alpha.0

diff --git a/Cargo.lock b/Cargo.lock
index bf279d1..ef07320 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "a"
-version = "0.1.2"
+version = "0.1.3-alpha.0"
 dependencies = [
  "b",
 ]
diff --git a/a/Cargo.toml b/a/Cargo.toml
index 5fb8bc6..4805959 100644
--- a/a/Cargo.toml
+++ b/a/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a"
-version = "0.1.2"
+version = "0.1.3-alpha.0"
 authors = ["Ed Page <epage@duosecurity.com>"]
 edition = "2018"
 publish = false
dap@zathras cargo-release-test $ git diff
diff --git a/b/Cargo.toml b/b/Cargo.toml
index 7707959..5b09e0c 100644
--- a/b/Cargo.toml
+++ b/b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "b"
-version = "0.1.2"
+version = "0.1.3-alpha.0"
 authors = ["Ed Page <epage@duosecurity.com>"]
 edition = "2018"
 publish = false
dap@zathras cargo-release-test $ cargo build
error: no matching package named `b` found
location searched: /Users/dap/oxide/cargo-release-test/b
prerelease package needs to be specified explicitly
b = { version = "0.1.3-alpha.0" }
required by package `a v0.1.3-alpha.0 (/Users/dap/oxide/cargo-release-test/a)`
$
```

I worked around this.  I reset my repo to the commit before I ran my fixup `cargo release`, then I updated the versions by hand, and now I can use `cargo release` with the next minor version number and it does the right thing.  So the only issue here is the case where someone's trying to fix up a failed release by running it with the same version number.